### PR TITLE
Added consent model

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -23,6 +23,17 @@ class User(db.Model):
         return password == 'valid'
 
 
+class Consent(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(
+        db.Integer, db.ForeignKey('user.id', ondelete='CASCADE'))
+    user = db.relationship('User')
+    oauth2_client_id = db.Column(
+        db.Integer, db.ForeignKey('oauth2_client.id', ondelete='CASCADE'))
+    oauth2_client = db.relationship('OAuth2Client')
+    scope = db.Column(db.String, nullable=False)
+
+
 class OAuth2Client(db.Model, OAuth2ClientMixin):
     __tablename__ = 'oauth2_client'
 


### PR DESCRIPTION
It is not strictly in OAuth specs, but I guess it is something often used, and [it will be someday in the spec](https://tools.ietf.org/id/draft-hunt-oauth-v2-user-a4c-01.html). A common usecase for this is the [prompt=None](https://openid.net/specs/openid-connect-core-1_0.html) parameter in the OIDC authorization request.

If you think this do not belong here, I can also make this PR for authlib/example-oidc-server.

